### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["John Philip"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Rust Bytes Challenges"
 description = "A collection of Rust Bytes weekly coding challenges"


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10