### PR TITLE
fix: add Rust Tip (Issue 69)

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -61,4 +61,5 @@
   - [Challenge 57](./challenges/challenge-57.md)
   - [Challenge 58](./challenges/challenge-58.md)
   - [Challenge 59](./challenges/challenge-59.md)
+  - [Challenge 60](./challenges/challenge-60.md)
 - [Resources](./resources.md)

--- a/src/challenges/challenge-60.md
+++ b/src/challenges/challenge-60.md
@@ -1,0 +1,21 @@
+# Challenge 60
+
+### Rust Tip: #[must_use] Attribute for Results and Options
+
+This attribute when applied to functions or types ensures that the Result or Option they return is actually handled.
+
+If the caller ignores it, the compiler will issue a warning. It's great for preventing silent errors.
+
+
+```rust
+// Rust Bytes Issue 69: #[must_use] Attribute for Results and Options
+#[must_use = "return value of `read` is an `io::Result` which must be handled"]
+fn read_data() -> std::io::Result<String> {
+    //
+    Ok("some data".to_string())
+}
+
+fn main() {
+    read_data(); // WARNING: unused `io::Result`
+}
+```


### PR DESCRIPTION
This pull request updates the book to include the rust tip shared in `Issue 69` of the weekly newsletter