### PR TITLE
fix: Add Rust Tip for Issue 71 and update Tip 69 with Playground link

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -63,4 +63,5 @@
   - [Challenge 59](./challenges/challenge-59.md)
   - [Challenge 60](./challenges/challenge-60.md)
   - [Challenge 61](./challenges/challenge-61.md)
+  - [Challenge 62](./challenges/challenge-62.md)
 - [Resources](./resources.md)

--- a/src/challenges/challenge-60.md
+++ b/src/challenges/challenge-60.md
@@ -11,7 +11,7 @@ If the caller ignores it, the compiler will issue a warning. It's great for prev
 // Rust Bytes Issue 69: #[must_use] Attribute for Results and Options
 #[must_use = "return value of `read` is an `io::Result` which must be handled"]
 fn read_data() -> std::io::Result<String> {
-    //
+    // ...
     Ok("some data".to_string())
 }
 
@@ -19,3 +19,5 @@ fn main() {
     read_data(); // WARNING: unused `io::Result`
 }
 ```
+
+Try it out yourself using this [Rust Playground Link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=84f3f3dce79ef4519a2849dfedfc112e).

--- a/src/challenges/challenge-62.md
+++ b/src/challenges/challenge-62.md
@@ -1,0 +1,25 @@
+# Challenge 62
+
+### Rust Tip: include_str! Macro
+
+`include_str!` is a macro that reads the content of a file at compile time, and embeds it as a `&'static str`
+
+#### When it's useful
+
+For bundling static assets (like configuration files, templates, or small images) directly into your executable.
+
+This avoids runtime file I/O and simplifies deployment as you don't need to ship separate asset files.
+
+
+```rust
+// Rust Bytes Issue 71: include_str! Macro
+
+const GREETING: &str = include_str!("data/greeting.txt");
+// Assuming you have a file `data/greeting.txt` in your project root with "Hello, Rust!"
+
+fn main() {
+    println!("{}", GREETING);
+}
+```
+
+You can play around with the code on [Rust Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=e49631ea658f2ddb94409c4dcdf9e816).


### PR DESCRIPTION
- Adds new Rust Tip (Issue 71)
- Includes missing Playground link for Rust Tip (Issue 69)