### PR TITLE
challenge-20.md - Question vs answer mismatch

### DIFF
--- a/src/challenges/challenge-20.md
+++ b/src/challenges/challenge-20.md
@@ -23,7 +23,7 @@ impl Printable for (i32, i32) {
 
 fn main() {
     (0, 0).print_value();
-    (0, 0).print_value();
+    (0, 0,).print_value();
 }
 ```
 


### PR DESCRIPTION
The answer talks about `(0, 0,)`, while the question had `(0, 0)`